### PR TITLE
Add an 'engine_args' option similar to tinytex's.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,14 +2,16 @@ Encoding: UTF-8
 Package: tikzDevice
 Type: Package
 Title: R Graphics Output in LaTeX Format
-Version: 0.12.1
+Version: 0.12.2
 Authors@R: c( person("Charlie", "Sharpsteen", role = "aut"),
         person("Cameron", "Bracken", role = "aut"), person("Kirill",
         "Müller", role = c("ctb"), email =
         "krlmlr+r@mailbox.org"), person("Yihui", "Xie", role = "ctb"),
         person("Ralf", "Stubner", email = "ralf.stubner@daqana.com", 
         role = "cre"), person("Nico", "Bellack", 
-        email = "nico.belack@daqana.com", role = "ctb") ) 
+        email = "nico.belack@daqana.com", role = "ctb"),
+	person("Emmanuel", "Charpentier",
+	email = "emm.charpentier@free.fr", role = "ctb")) 
 URL: https://github.com/daqana/tikzDevice
 BugReports: https://github.com/daqana/tikzDevice/issues
 Description: Provides a graphics output device for R that records plots

--- a/R/deviceUtils.R
+++ b/R/deviceUtils.R
@@ -65,7 +65,10 @@ getDocumentPointsize <- function(docString) {
 #' @export
 setTikzDefaults <- function(overwrite = TRUE) {
   tikzDefaults <- list(
+
     tikzDefaultEngine = "pdftex",
+
+    tikzEngineArgs = "",
 
     tikzLatex = getOption("tikzLatexDefault"),
 
@@ -360,6 +363,7 @@ tikzCompilerInfo <- function(verbose = TRUE) {
 #' @export
 tikzTest <- function(texString = "A",
                      engine = getOption("tikzDefaultEngine"),
+                     engine_args=getOption("tikzEngineArgs"),
                      documentDeclaration = getOption("tikzDocumentDeclaration"),
                      packages) {
   latex_cmd <- get_latex_cmd(engine)
@@ -367,6 +371,7 @@ tikzTest <- function(texString = "A",
   getLatexStrWidth(
     texString,
     engine = engine,
+    engine_args = engine_args,
     documentDeclaration = documentDeclaration,
     packages = packages,
     diagnose = TRUE

--- a/R/latexStrWidth.R
+++ b/R/latexStrWidth.R
@@ -40,9 +40,12 @@
 #'
 #' @references PGF Manual
 #' @export
-getLatexStrWidth <- function(texString, cex = 1, face = 1, engine = getOption("tikzDefaultEngine"),
-                             documentDeclaration = getOption("tikzDocumentDeclaration"), packages,
-                             verbose = interactive(), diagnose = FALSE) {
+getLatexStrWidth <- function(texString, cex = 1, face = 1,
+                             engine = getOption("tikzDefaultEngine"),
+                             engine_args=getOption("tikzEngineArgs"),
+                             documentDeclaration = getOption("tikzDocumentDeclaration"),
+                             packages, verbose = interactive(),
+                             diagnose = FALSE) {
   texString <- enc2utf8(texString) # convert the encoding of input string to UTF8
 
   switch(engine,
@@ -77,7 +80,7 @@ getLatexStrWidth <- function(texString, cex = 1, face = 1, engine = getOption("t
   TeXMetrics <- list(
     type = "string", scale = cex, face = face, value = texString,
     documentDeclaration = documentDeclaration,
-    packages = packages, engine = engine
+    packages = packages, engine = engine, engine_args = engine_args
   )
 
   if (diagnose) {
@@ -127,6 +130,7 @@ getLatexStrWidth <- function(texString, cex = 1, face = 1, engine = getOption("t
 #'
 #' @export
 getLatexCharMetrics <- function(charCode, cex = 1, face = 1, engine = getOption("tikzDefaultEngine"),
+                                engine_args = getOption("tikzEngineArgs"),
                                 documentDeclaration = getOption("tikzDocumentDeclaration"), packages,
                                 verbose = interactive()) {
 
@@ -203,7 +207,7 @@ getLatexCharMetrics <- function(charCode, cex = 1, face = 1, engine = getOption(
   TeXMetrics <- list(
     type = "char", scale = cex, face = face, value = charCode,
     documentDeclaration = documentDeclaration,
-    packages = packages, engine = engine
+    packages = packages, engine = engine, engine_args = engine_args
   )
 
   # Check to see if we have metrics stored in
@@ -401,11 +405,10 @@ getMetricsFromLatex <- function(TeXMetrics, verbose = verbose, diagnose = FALSE)
   latexCmd <- get_latex_cmd(TeXMetrics$engine)
 
   # Append the batchmode flag to increase LaTeX
-  # efficiency.
-  latexCmd <- paste(
-    shQuote(latexCmd), "-interaction=batchmode", "-halt-on-error",
-    "-output-directory", shQuote(texDir), shQuote(texFile)
-  )
+  # efficiency, and other useful flags...
+  latexCmd <- paste(shQuote(latexCmd), TeXMetrics$engine_args,
+                    "-interaction=batchmode", "-halt-on-error",
+                    "-output-directory", shQuote(texDir), shQuote(texFile))
 
   message("Running command: ", latexCmd)
 

--- a/R/tikz.R
+++ b/R/tikz.R
@@ -50,69 +50,81 @@
 #' automatically written if the path of a color file `colorFileName` is
 #' set.
 #'
-#' @param file,filename A character string indicating the desired path to the output
-#'   file. If both arguments are used in the function call, `file` will be
-#'   preferred.
+#' @param file,filename A character string indicating the desired path
+#'     to the output file. If both arguments are used in the function
+#'     call, `file` will be preferred.
 #' @param width The width of the output figure, in **inches**.
 #' @param height The height of the output figure, in **inches**.
-#' @param onefile Should output be directed to separate environments in a
-#'   single file (default `TRUE`). If `FALSE` this option works
-#'   exactly like the argument of the same name to [pdf()]
-#'   (see there for more details).
+#' @param onefile Should output be directed to separate environments
+#'     in a single file (default `TRUE`). If `FALSE` this option works
+#'     exactly like the argument of the same name to [pdf()] (see
+#'     there for more details).
 #' @param bg The starting background color for the plot.
 #' @param fg The starting foreground color for the plot.
-#' @param pointsize Base pointsize used in the LaTeX document.  This option is
-#'   only used if a valid pointsize cannot be extracted from the value of
-#'   `getOption("tikzDocumentDeclaration")`.  See the section "Font Size
-#'   Calculations" in \link{tikzDevice-package} for more details.
+#' @param pointsize Base pointsize used in the LaTeX document.  This
+#'     option is only used if a valid pointsize cannot be extracted
+#'     from the value of `getOption("tikzDocumentDeclaration")`.  See
+#'     the section "Font Size Calculations" in
+#'     \link{tikzDevice-package} for more details.
 #' @param lwdUnit The number of `pt`s in LaTeX that `lwd = 1` in R is
-#'   translated to.  Defaults to 0.4 (LaTeX and TikZ default); for compatibility
-#'   with R default, please use 72.27/96 (96 pixels in R is 1 inch, which is 72.27
-#'   points in TeX).
-#' @param standAlone A logical value indicating whether the output file should
-#'   be suitable for direct processing by LaTeX. A value of `FALSE`
-#'   indicates that the file is intended for inclusion in a larger document.
-#'   See \sQuote{Details}.
-#' @param bareBones A logical value.  When `TRUE` the figure will not be
-#'   wrapped in a `tikzpicture` environment.  This option is useful for
-#'   embedding one TikZ picture within another. When `TRUE` multipage
-#'   output will be drawn on a single page.
-#' @param console Should the output of tikzDevice be directed to the R console
-#'   (default `FALSE`). This is useful for dumping tikz output directly into a
-#'   LaTeX document via [sink()].  If TRUE, the `file` argument
-#'   is ignored. Setting `file = ''` is equivalent to setting
-#'   `console=TRUE`.
-#' @param sanitize Should special latex characters be replaced (Default FALSE).
-#'   See the section "Options That Affect Package Behavior" for which
-#'   characters are replaced.
-#' @param engine a string specifying which TeX engine to use. Possible values
-#'   are 'pdftex', 'xetex' and 'luatex'. See the Unicode section of
-#'   \link{tikzDevice-package} for details.
-#' @param documentDeclaration See the sections "Options That Affect Package
-#'   Behavior" and "Font Size Calculations" of \link{tikzDevice-package}
-#'   for more details.
-#' @param packages See the section "Options That Affect Package Behavior" of
-#'   \link{tikzDevice-package}.
-#' @param footer See the section "Options That Affect Package Behavior" of
-#'   \link{tikzDevice-package}.
-#' @param symbolicColors A logical value indicating whether colors are written
-#'  as RGB values or as symbolic names in which case the need to be defined in
-#'  the LaTeX document. These definitions can be generated with the following
-#'  `colorFileName` parameter. See also the section "Options That Affect
-#'  Package Behavior" of \link{tikzDevice-package}.
-#' @param colorFileName a character string indicating where the color map for
-#'  symbolic colors is to be stored. It can contain a placeholder \code{\%s}
-#'  where the tikz filename is inserted. If the string is empty, no file is
-#'  written.
-#' @param maxSymbolicColors an integer number indicating the maximal number
-#'  of distinct colors to write symbolically. Any excess color will be defined
-#'  as if `symbolicColors` was set to `FALSE`. See also the section
-#'  "Options That Affect Package Behavior" of \link{tikzDevice-package}.
-#' @param timestamp A logical value indicating whether a timestamp is written
-#'  to the TeX file.
-#' @param verbose A logical value indicating whether diagnostic messages are
-#'  printed when measuring dimensions of strings. Defaults to `TRUE` in
-#'  interactive mode only, to `FALSE` otherwise.
+#'     translated to.  Defaults to 0.4 (LaTeX and TikZ default); for
+#'     compatibility with R default, please use 72.27/96 (96 pixels in
+#'     R is 1 inch, which is 72.27 points in TeX).
+#' @param standAlone A logical value indicating whether the output
+#'     file should be suitable for direct processing by LaTeX. A value
+#'     of `FALSE` indicates that the file is intended for inclusion in
+#'     a larger document.  See \sQuote{Details}.
+#' @param bareBones A logical value.  When `TRUE` the figure will not
+#'     be wrapped in a `tikzpicture` environment.  This option is
+#'     useful for embedding one TikZ picture within another. When
+#'     `TRUE` multipage output will be drawn on a single page.
+#' @param console Should the output of tikzDevice be directed to the R
+#'     console (default `FALSE`). This is useful for dumping tikz
+#'     output directly into a LaTeX document via [sink()].  If TRUE,
+#'     the `file` argument is ignored. Setting `file = ''` is
+#'     equivalent to setting `console=TRUE`.
+#' @param sanitize Should special latex characters be replaced
+#'     (Default FALSE).  See the section
+#'     "Options That Affect Package Behavior" for which characters are
+#'     replaced.
+#' @param engine a string specifying which TeX engine to use. Possible
+#'     values are 'pdftex', 'xetex' and 'luatex'. See the Unicode
+#'     section of \link{tikzDevice-package} for details.
+#' @param engine_args Command-line arguments to be passed toengine(can
+#'     be set in the global option tikzEngineArgs,
+#'     e.g. `options(tikzEngineArgs ='-shell-escape')`
+#' @param documentDeclaration See the sections
+#'     "Options That Affect Package Behavior" and
+#'     "Font Size Calculations" of \link{tikzDevice-package} for more
+#'     details.
+#' @param packages See the section
+#'     "Options That Affect Package Behavior" of
+#'     \link{tikzDevice-package}.
+#' @param footer See the section
+#'     "Options That Affect Package Behavior" of
+#'     \link{tikzDevice-package}.
+#' @param symbolicColors A logical value indicating whether colors are
+#'     written as RGB values or as symbolic names in which case the
+#'     need to be defined in the LaTeX document. These definitions can
+#'     be generated with the following `colorFileName` parameter. See
+#'     also the section "Options That Affect Package Behavior" of
+#'     \link{tikzDevice-package}.
+#' @param colorFileName a character string indicating where the color
+#'     map for symbolic colors is to be stored. It can contain a
+#'     placeholder \code{\%s} where the tikz filename is inserted. If
+#'     the string is empty, no file is written.
+#' @param maxSymbolicColors an integer number indicating the maximal
+#'     number of distinct colors to write symbolically. Any excess
+#'     color will be defined as if `symbolicColors` was set to
+#'     `FALSE`. See also the section
+#'     "Options That Affect Package Behavior" of
+#'     \link{tikzDevice-package}.
+#' @param timestamp A logical value indicating whether a timestamp is
+#'     written to the TeX file.
+#' @param verbose A logical value indicating whether diagnostic
+#'     messages are printed when measuring dimensions of
+#'     strings. Defaults to `TRUE` in interactive mode only, to
+#'     `FALSE` otherwise.
 #'
 #' @return `tikz()` returns no values.
 #'
@@ -217,6 +229,7 @@ tikz <- function(file = filename,
                  bg="transparent", fg="black", pointsize = 10, lwdUnit = getOption("tikzLwdUnit"),
                  standAlone = FALSE, bareBones = FALSE, console = FALSE, sanitize = FALSE,
                  engine = getOption("tikzDefaultEngine"),
+                 engine_args = getOption("tikzEngineArgs"),
                  documentDeclaration = getOption("tikzDocumentDeclaration"),
                  packages,
                  footer = getOption("tikzFooter"),
@@ -309,7 +322,7 @@ tikz <- function(file = filename,
   .External(
     TikZ_StartDevice, file, width, height, onefile, bg, fg, baseSize, lwdUnit,
     standAlone, bareBones, documentDeclaration, packages, footer, console,
-    sanitize, engine, symbolicColors, colorFileName, maxSymbolicColors,
+    sanitize, engine, engine_args, symbolicColors, colorFileName, maxSymbolicColors,
     timestamp, verbose
   )
 

--- a/R/tikzDevice-package.R
+++ b/R/tikzDevice-package.R
@@ -28,6 +28,12 @@
 #'   values trigger the use of the `pdflatex`, `xelatex` and
 #'   `lualatex` compilers.  }
 #'
+#'   \item{`tikzEngineArgs`}{ Specifies supplementary command line
+#'   arguments to be passed to the engine. Use this to satisfy such
+#'   requirements of LaTeX packages used in your documents (example :
+#'   the `minted` package requires `-shell-escape` in order to write
+#'   its its intermediary files). }
+#'
 #'   \item{`tikzLatex`}{ Specifies the location of the LaTeX compiler to be
 #'   used by \pkg{tikzDevice}. Setting this option may help the package locate a
 #'   missing compiler. The default is searched for when the package is loaded,

--- a/man/getLatexStrWidth.Rd
+++ b/man/getLatexStrWidth.Rd
@@ -7,11 +7,13 @@
 \usage{
 getLatexStrWidth(texString, cex = 1, face = 1,
   engine = getOption("tikzDefaultEngine"),
+  engine_args = getOption("tikzEngineArgs"),
   documentDeclaration = getOption("tikzDocumentDeclaration"), packages,
   verbose = interactive(), diagnose = FALSE)
 
 getLatexCharMetrics(charCode, cex = 1, face = 1,
   engine = getOption("tikzDefaultEngine"),
+  engine_args = getOption("tikzEngineArgs"),
   documentDeclaration = getOption("tikzDocumentDeclaration"), packages,
   verbose = interactive())
 }
@@ -25,20 +27,27 @@ applied to device output.}
 \item{face}{an integer in the range \code{1:5} that specifies the font face to
 use. See \link{par} for details.}
 
-\item{engine}{a string specifying which TeX engine to use. Possible values
-are 'pdftex', 'xetex' and 'luatex'. See the Unicode section of
-\link{tikzDevice-package} for details.}
+\item{engine}{a string specifying which TeX engine to use. Possible
+values are 'pdftex', 'xetex' and 'luatex'. See the Unicode
+section of \link{tikzDevice-package} for details.}
 
-\item{documentDeclaration}{See the sections "Options That Affect Package
-Behavior" and "Font Size Calculations" of \link{tikzDevice-package}
-for more details.}
+\item{engine_args}{Command-line arguments to be passed toengine(can
+be set in the global option tikzEngineArgs,
+e.g. \code{options(tikzEngineArgs ='-shell-escape')}}
 
-\item{packages}{See the section "Options That Affect Package Behavior" of
+\item{documentDeclaration}{See the sections
+"Options That Affect Package Behavior" and
+"Font Size Calculations" of \link{tikzDevice-package} for more
+details.}
+
+\item{packages}{See the section
+"Options That Affect Package Behavior" of
 \link{tikzDevice-package}.}
 
-\item{verbose}{A logical value indicating whether diagnostic messages are
-printed when measuring dimensions of strings. Defaults to \code{TRUE} in
-interactive mode only, to \code{FALSE} otherwise.}
+\item{verbose}{A logical value indicating whether diagnostic
+messages are printed when measuring dimensions of
+strings. Defaults to \code{TRUE} in interactive mode only, to
+\code{FALSE} otherwise.}
 
 \item{diagnose}{pass \code{TRUE} to print detailed error information.}
 

--- a/man/tikz.Rd
+++ b/man/tikz.Rd
@@ -10,6 +10,7 @@ tikz(file = filename, filename = ifelse(onefile, "./Rplots.tex",
   lwdUnit = getOption("tikzLwdUnit"), standAlone = FALSE,
   bareBones = FALSE, console = FALSE, sanitize = FALSE,
   engine = getOption("tikzDefaultEngine"),
+  engine_args = getOption("tikzEngineArgs"),
   documentDeclaration = getOption("tikzDocumentDeclaration"), packages,
   footer = getOption("tikzFooter"),
   symbolicColors = getOption("tikzSymbolicColors"),
@@ -18,89 +19,102 @@ tikz(file = filename, filename = ifelse(onefile, "./Rplots.tex",
   timestamp = TRUE, verbose = interactive())
 }
 \arguments{
-\item{file, filename}{A character string indicating the desired path to the output
-file. If both arguments are used in the function call, \code{file} will be
-preferred.}
+\item{file, filename}{A character string indicating the desired path
+to the output file. If both arguments are used in the function
+call, \code{file} will be preferred.}
 
 \item{width}{The width of the output figure, in \strong{inches}.}
 
 \item{height}{The height of the output figure, in \strong{inches}.}
 
-\item{onefile}{Should output be directed to separate environments in a
-single file (default \code{TRUE}). If \code{FALSE} this option works
-exactly like the argument of the same name to \code{\link[=pdf]{pdf()}}
-(see there for more details).}
+\item{onefile}{Should output be directed to separate environments
+in a single file (default \code{TRUE}). If \code{FALSE} this option works
+exactly like the argument of the same name to \code{\link[=pdf]{pdf()}} (see
+there for more details).}
 
 \item{bg}{The starting background color for the plot.}
 
 \item{fg}{The starting foreground color for the plot.}
 
-\item{pointsize}{Base pointsize used in the LaTeX document.  This option is
-only used if a valid pointsize cannot be extracted from the value of
-\code{getOption("tikzDocumentDeclaration")}.  See the section "Font Size
-Calculations" in \link{tikzDevice-package} for more details.}
+\item{pointsize}{Base pointsize used in the LaTeX document.  This
+option is only used if a valid pointsize cannot be extracted
+from the value of \code{getOption("tikzDocumentDeclaration")}.  See
+the section "Font Size Calculations" in
+\link{tikzDevice-package} for more details.}
 
 \item{lwdUnit}{The number of \code{pt}s in LaTeX that \code{lwd = 1} in R is
-translated to.  Defaults to 0.4 (LaTeX and TikZ default); for compatibility
-with R default, please use 72.27/96 (96 pixels in R is 1 inch, which is 72.27
-points in TeX).}
+translated to.  Defaults to 0.4 (LaTeX and TikZ default); for
+compatibility with R default, please use 72.27/96 (96 pixels in
+R is 1 inch, which is 72.27 points in TeX).}
 
-\item{standAlone}{A logical value indicating whether the output file should
-be suitable for direct processing by LaTeX. A value of \code{FALSE}
-indicates that the file is intended for inclusion in a larger document.
-See \sQuote{Details}.}
+\item{standAlone}{A logical value indicating whether the output
+file should be suitable for direct processing by LaTeX. A value
+of \code{FALSE} indicates that the file is intended for inclusion in
+a larger document.  See \sQuote{Details}.}
 
-\item{bareBones}{A logical value.  When \code{TRUE} the figure will not be
-wrapped in a \code{tikzpicture} environment.  This option is useful for
-embedding one TikZ picture within another. When \code{TRUE} multipage
-output will be drawn on a single page.}
+\item{bareBones}{A logical value.  When \code{TRUE} the figure will not
+be wrapped in a \code{tikzpicture} environment.  This option is
+useful for embedding one TikZ picture within another. When
+\code{TRUE} multipage output will be drawn on a single page.}
 
-\item{console}{Should the output of tikzDevice be directed to the R console
-(default \code{FALSE}). This is useful for dumping tikz output directly into a
-LaTeX document via \code{\link[=sink]{sink()}}.  If TRUE, the \code{file} argument
-is ignored. Setting \code{file = ''} is equivalent to setting
-\code{console=TRUE}.}
+\item{console}{Should the output of tikzDevice be directed to the R
+console (default \code{FALSE}). This is useful for dumping tikz
+output directly into a LaTeX document via \code{\link[=sink]{sink()}}.  If TRUE,
+the \code{file} argument is ignored. Setting \code{file = ''} is
+equivalent to setting \code{console=TRUE}.}
 
-\item{sanitize}{Should special latex characters be replaced (Default FALSE).
-See the section "Options That Affect Package Behavior" for which
-characters are replaced.}
+\item{sanitize}{Should special latex characters be replaced
+(Default FALSE).  See the section
+"Options That Affect Package Behavior" for which characters are
+replaced.}
 
-\item{engine}{a string specifying which TeX engine to use. Possible values
-are 'pdftex', 'xetex' and 'luatex'. See the Unicode section of
-\link{tikzDevice-package} for details.}
+\item{engine}{a string specifying which TeX engine to use. Possible
+values are 'pdftex', 'xetex' and 'luatex'. See the Unicode
+section of \link{tikzDevice-package} for details.}
 
-\item{documentDeclaration}{See the sections "Options That Affect Package
-Behavior" and "Font Size Calculations" of \link{tikzDevice-package}
-for more details.}
+\item{engine_args}{Command-line arguments to be passed toengine(can
+be set in the global option tikzEngineArgs,
+e.g. \code{options(tikzEngineArgs ='-shell-escape')}}
 
-\item{packages}{See the section "Options That Affect Package Behavior" of
+\item{documentDeclaration}{See the sections
+"Options That Affect Package Behavior" and
+"Font Size Calculations" of \link{tikzDevice-package} for more
+details.}
+
+\item{packages}{See the section
+"Options That Affect Package Behavior" of
 \link{tikzDevice-package}.}
 
-\item{footer}{See the section "Options That Affect Package Behavior" of
+\item{footer}{See the section
+"Options That Affect Package Behavior" of
 \link{tikzDevice-package}.}
 
-\item{symbolicColors}{A logical value indicating whether colors are written
-as RGB values or as symbolic names in which case the need to be defined in
-the LaTeX document. These definitions can be generated with the following
-\code{colorFileName} parameter. See also the section "Options That Affect
-Package Behavior" of \link{tikzDevice-package}.}
+\item{symbolicColors}{A logical value indicating whether colors are
+written as RGB values or as symbolic names in which case the
+need to be defined in the LaTeX document. These definitions can
+be generated with the following \code{colorFileName} parameter. See
+also the section "Options That Affect Package Behavior" of
+\link{tikzDevice-package}.}
 
-\item{colorFileName}{a character string indicating where the color map for
-symbolic colors is to be stored. It can contain a placeholder \code{\%s}
-where the tikz filename is inserted. If the string is empty, no file is
-written.}
+\item{colorFileName}{a character string indicating where the color
+map for symbolic colors is to be stored. It can contain a
+placeholder \code{\%s} where the tikz filename is inserted. If
+the string is empty, no file is written.}
 
-\item{maxSymbolicColors}{an integer number indicating the maximal number
-of distinct colors to write symbolically. Any excess color will be defined
-as if \code{symbolicColors} was set to \code{FALSE}. See also the section
-"Options That Affect Package Behavior" of \link{tikzDevice-package}.}
+\item{maxSymbolicColors}{an integer number indicating the maximal
+number of distinct colors to write symbolically. Any excess
+color will be defined as if \code{symbolicColors} was set to
+\code{FALSE}. See also the section
+"Options That Affect Package Behavior" of
+\link{tikzDevice-package}.}
 
-\item{timestamp}{A logical value indicating whether a timestamp is written
-to the TeX file.}
+\item{timestamp}{A logical value indicating whether a timestamp is
+written to the TeX file.}
 
-\item{verbose}{A logical value indicating whether diagnostic messages are
-printed when measuring dimensions of strings. Defaults to \code{TRUE} in
-interactive mode only, to \code{FALSE} otherwise.}
+\item{verbose}{A logical value indicating whether diagnostic
+messages are printed when measuring dimensions of
+strings. Defaults to \code{TRUE} in interactive mode only, to
+\code{FALSE} otherwise.}
 }
 \value{
 \code{tikz()} returns no values.

--- a/man/tikzDevice-package.Rd
+++ b/man/tikzDevice-package.Rd
@@ -32,6 +32,12 @@ are \code{pdftex}, \code{xetex} or \code{luatex}. Respectively, these
 values trigger the use of the \code{pdflatex}, \code{xelatex} and
 \code{lualatex} compilers.  }
 
+\item{\code{tikzEngineArgs}}{ Specifies supplementary command line
+arguments to be passed to the engine. Use this to satisfy such
+requirements of LaTeX packages used in your documents (example :
+the \code{minted} package requires \code{-shell-escape} in order to write
+its its intermediary files). }
+
 \item{\code{tikzLatex}}{ Specifies the location of the LaTeX compiler to be
 used by \pkg{tikzDevice}. Setting this option may help the package locate a
 missing compiler. The default is searched for when the package is loaded,

--- a/man/tikzTest.Rd
+++ b/man/tikzTest.Rd
@@ -5,21 +5,28 @@
 \title{Test invocation of a LaTeX engine.}
 \usage{
 tikzTest(texString = "A", engine = getOption("tikzDefaultEngine"),
+  engine_args = getOption("tikzEngineArgs"),
   documentDeclaration = getOption("tikzDocumentDeclaration"), packages)
 }
 \arguments{
 \item{texString}{An arbitrary string for which the width is to be
 calculated.  May contain LaTeX markup.}
 
-\item{engine}{a string specifying which TeX engine to use. Possible values
-are 'pdftex', 'xetex' and 'luatex'. See the Unicode section of
-\link{tikzDevice-package} for details.}
+\item{engine}{a string specifying which TeX engine to use. Possible
+values are 'pdftex', 'xetex' and 'luatex'. See the Unicode
+section of \link{tikzDevice-package} for details.}
 
-\item{documentDeclaration}{See the sections "Options That Affect Package
-Behavior" and "Font Size Calculations" of \link{tikzDevice-package}
-for more details.}
+\item{engine_args}{Command-line arguments to be passed toengine(can
+be set in the global option tikzEngineArgs,
+e.g. \code{options(tikzEngineArgs ='-shell-escape')}}
 
-\item{packages}{See the section "Options That Affect Package Behavior" of
+\item{documentDeclaration}{See the sections
+"Options That Affect Package Behavior" and
+"Font Size Calculations" of \link{tikzDevice-package} for more
+details.}
+
+\item{packages}{See the section
+"Options That Affect Package Behavior" of
 \link{tikzDevice-package}.}
 }
 \description{

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -79,7 +79,7 @@ SEXP TikZ_StartDevice ( SEXP args ){
   const char *bg, *fg;
   double width, height;
   Rboolean standAlone, bareBones;
-  const char *documentDeclaration, *packages, *footer;
+  const char *documentDeclaration, *engine_args, *packages, *footer;
   double baseSize, lwdUnit;
   Rboolean console, sanitize, onefile, symbolicColors;
 
@@ -165,6 +165,11 @@ SEXP TikZ_StartDevice ( SEXP args ){
   int engine = asInteger(CAR(args)); args = CDR(args);
 
   /*
+   * Engine args : allow to pass options to the TeX engine
+  */
+  engine_args = CHAR(asChar(CAR(args))); args=CDR(args);
+
+  /*
    * Should symbolic names be used (red instead of 1.0, 1.0, 1.0)
    */
   symbolicColors = asLogical(CAR(args)); args = CDR(args);
@@ -200,10 +205,11 @@ SEXP TikZ_StartDevice ( SEXP args ){
      * R graphics function hooks with the appropriate C routines
      * in this file.
     */
-    if( !TikZ_Setup( deviceInfo, fileName, width, height, onefile, bg, fg, baseSize, lwdUnit,
-        standAlone, bareBones, documentDeclaration, packages,
-        footer, console, sanitize, engine, symbolicColors, colorFileName,
-        maxSymbolicColors, timestamp, verbose ) ){
+    if( !TikZ_Setup( deviceInfo, fileName, width, height, onefile, bg, fg,
+		     baseSize, lwdUnit, standAlone, bareBones,
+		     documentDeclaration, packages, footer, console, sanitize,
+		     engine, engine_args, symbolicColors, colorFileName,
+		     maxSymbolicColors, timestamp, verbose ) ){
       /*
        * If setup was unsuccessful, destroy the device and return
        * an error message.
@@ -248,6 +254,7 @@ static Rboolean TikZ_Setup(
   const char *documentDeclaration,
   const char *packages, const char *footer,
   Rboolean console, Rboolean sanitize, int engine,
+  const char *engine_args,
   Rboolean symbolicColors, const char* colorFileName,
   int maxSymbolicColors, Rboolean timestamp, Rboolean verbose){
 
@@ -305,6 +312,7 @@ static Rboolean TikZ_Setup(
   tikzInfo->stringWidthCalls = 0;
 
   tikzInfo->documentDeclaration = calloc_strcpy(documentDeclaration);
+  tikzInfo->engine_args = calloc_strcpy(engine_args);
   tikzInfo->packages = calloc_strcpy(packages);
   tikzInfo->footer = calloc_strcpy(footer);
   tikzInfo->symbolicColors = symbolicColors;

--- a/src/tikzDevice.h
+++ b/src/tikzDevice.h
@@ -67,6 +67,7 @@ typedef struct {
   char *outColorFileName;
   char *originalColorFileName;
   tikz_engine engine;
+  char *engine_args;
   int rasterFileCount;
   int pageNum;
   double lwdUnit;
@@ -112,7 +113,7 @@ static Rboolean TikZ_Setup(
     Rboolean standAlone, Rboolean bareBones,
     const char *documentDeclaration,
     const char *packages, const char *footer,
-    Rboolean console, Rboolean sanitize, int engine,
+    Rboolean console, Rboolean sanitize, int engine, const char *engine_args,
     Rboolean symbolicColors, const char *colorFileName,
     int maxSymbolicColors, Rboolean timestamp, Rboolean verbose );
 

--- a/vignettes/tikzDevice.Rnw
+++ b/vignettes/tikzDevice.Rnw
@@ -2128,3 +2128,7 @@ Now for a little shameless self promotion. The authors of \pkg{tikzDevice} have 
 \bibliography{refs}
 
 \end{document}\n
+
+%% Local Variables:
+%% TeX-master: "tikzDevice"
+%% End:


### PR DESCRIPTION
The [issue #172](https://github.com/daqana/tikzDevice/issues/172) reported the difficulties to use `tikzDevice` in a \LaTeX file using packages needing the `-shell-escape` option to {pdf|xe|lua}latex in order to access the filesystem and system commands.

This patch request implements a solution to [issue #172](https://github.com/daqana/tikzDevice/issues/172). it adds an argument `engine_args` similar to the one present in [tinytex](https://cran.r-project.org/web/packages/tinytex/index.html), with a corresponding global option `tikzEngineArgs`.

This patch request passes `R CMD check --as-cran`. I have installed it on R 3.4.4 and 3.5.1.

Of note : this is *not* sufficient to use it transparently for use with `knitr` ; in order to use t transparently, you *also* tave to set `tinytex.engine_args` to the same `-shell-escape` value. I think that this is a bug in the way my system (`emacs`) invokes the various compilers, an consider it a different problem.

Home this helps...