### PR TITLE
Fix typo that prevented mitre line joins to work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: tikzDevice
 Type: Package
 Title: R Graphics Output in LaTeX Format
-Version: 0.12.1
+Version: 0.12.2
 Authors@R: c( person("Charlie", "Sharpsteen", role = "aut"),
         person("Cameron", "Bracken", role = "aut"), person("Kirill",
         "Müller", role = c("ctb"), email =

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# tikzDevice 0.12.2 (unreleased)
+
+Bug fixes
+---------
+
+- tikzDevice correctly translates the `lmitre = n` parameter of the `plot()` 
+  function now (#178)
+
 # tikzDevice 0.12.1 (unreleased)
 
 Bug fixes

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -1943,7 +1943,9 @@ static void TikZ_WriteLineStyle(pGEcontext plotParams, tikzDevDesc *tikzInfo)
     case GE_MITRE_JOIN:
       /* Default if nothing is specified */
       if(plotParams->lmitre != 10)
-        printOutput(tikzInfo, ",mitre limit=%4.2f",plotParams->lmitre);
+        /* Here it has to be "miter" because pgfkeys wants it to be
+         * written this way. */
+        printOutput(tikzInfo, ",miter limit=%4.2f",plotParams->lmitre);
       break;
     case GE_BEVEL_JOIN:
       printOutput(tikzInfo, ",line join=bevel");


### PR DESCRIPTION
tikzDevice correctly translates the `lmitre = n` parameter of the `plot()`
function now (#178)