### PR TITLE
Need double escapes in help page

### DIFF
--- a/R/tikzDevice-package.R
+++ b/R/tikzDevice-package.R
@@ -58,7 +58,7 @@
 #'   declaration used in output files when `standAlone == TRUE`.
 #'   `tikzDocumentDeclaration` also influences the calculation of font
 #'   metrics. The default value is: \code{options(tikzDocumentDeclaration =
-#'   "\\documentclass[10pt]{article}")} }
+#'   "\\\\documentclass[10pt]{article}")} }
 #'
 #'   \item{`tikzLatexPackages`}{ A character vector. These are the packages
 #'   which are included when using the `pdftex` engine and
@@ -80,8 +80,8 @@
 #'   packages which are additionally loaded when doing font metric calculations.
 #'   As you see below, the font encoding is set to Type 1. This is very
 #'   important so that character codes of LaTeX and match up. The default value
-#'   is: \code{options(tikzMetricPackages = c( "\\usepackage[utf8]{inputenc}",
-#'   "\\usepackage[T1]{fontenc}", "\\usetikzlibrary{calc}" ))} }
+#'   is: \code{options(tikzMetricPackages = c( "\\\\usepackage[utf8]{inputenc}",
+#'   "\\\\usepackage[T1]{fontenc}", "\\\\usetikzlibrary{calc}" ))} }
 #'
 #'   \item{`tikzUnicodeMetricPackages`}{ This vector is used when font
 #'   metric calculations are performed using the `xetex` or `luatex`

--- a/man/tikzDevice-package.Rd
+++ b/man/tikzDevice-package.Rd
@@ -61,7 +61,7 @@ may be specified by setting the value of \code{tikzMetricsDictionary} in
 declaration used in output files when \code{standAlone == TRUE}.
 \code{tikzDocumentDeclaration} also influences the calculation of font
 metrics. The default value is: \code{options(tikzDocumentDeclaration =
-  "\\documentclass[10pt]{article}")} }
+  "\\\\documentclass[10pt]{article}")} }
 
 \item{\code{tikzLatexPackages}}{ A character vector. These are the packages
 which are included when using the \code{pdftex} engine and
@@ -83,8 +83,8 @@ when \code{standAlone==TRUE}.  }
 packages which are additionally loaded when doing font metric calculations.
 As you see below, the font encoding is set to Type 1. This is very
 important so that character codes of LaTeX and match up. The default value
-is: \code{options(tikzMetricPackages = c( "\\usepackage[utf8]{inputenc}",
-  "\\usepackage[T1]{fontenc}", "\\usetikzlibrary{calc}" ))} }
+is: \code{options(tikzMetricPackages = c( "\\\\usepackage[utf8]{inputenc}",
+  "\\\\usepackage[T1]{fontenc}", "\\\\usetikzlibrary{calc}" ))} }
 
 \item{\code{tikzUnicodeMetricPackages}}{ This vector is used when font
 metric calculations are performed using the \code{xetex} or \code{luatex}


### PR DESCRIPTION
The `package?tikzDevice` describes options affecting the device that need LaTeX code containing backslashes.  These need to be escaped twice, so that the escapes show up in the help file.